### PR TITLE
feat : Implement APIs for retrieving words and sentences

### DIFF
--- a/haru_backend/app/serializers.py
+++ b/haru_backend/app/serializers.py
@@ -1,15 +1,15 @@
 from rest_framework import serializers
-from .models import Words, Sentence
+from .models import Word, Sentence
 
 class SenetnceSerializer(serializers.ModelSerializer):
     class Meta :
         model = Sentence
         field = ['sentence_id', 'kr', 'jp']
 
-class WordsSerializer(serializers.ModelSerializer):
+class WordSerializer(serializers.ModelSerializer):
     sentence = SenetnceSerializer()
-    
+
     class Meta:
-        model = Words
+        model = Word
         fields = ['word_id', 'link', 'word_class', 'star_count',
                   "kanji", "furigana", "word_meaning", "level", "sentence"]

--- a/haru_backend/app/urls.py
+++ b/haru_backend/app/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from . import views
+from .views import WordListView, SentenceListView
 
 urlpatterns = [
-    
+    path('words/', WordListView.as_view(), name='word-list'),
+    path('sentences/', SentenceListView.as_view(), name='sentence-list')
 ]

--- a/haru_backend/app/views.py
+++ b/haru_backend/app/views.py
@@ -1,2 +1,17 @@
-from django.shortcuts import render
-from .models import Product
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from .models import Word, Sentence
+from .serializers import WordSerializer, SenetnceSerializer
+
+class WordListView(APIView):
+    def get(self, request) :
+        words = Word.objects.all()
+        serializer = WordSerializer(words, many = True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+    
+class SentenceListView(APIView):
+    def get(self, request):
+        sentences = Sentence.objects.all()
+        serializer = SenetnceSerializer(sentences, many = True)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Pull Request: Implement APIs for retrieving words and sentences

### 요약
이 PR은 JLPT 단어와 해당 단어에 연관된 문장을 조회하는 API를 구현합니다. 두 가지 주요 엔드포인트가 추가되었습니다:
1. **`GET /words/`**: 모든 단어를 조회합니다.
2. **`GET /sentences/`**: 모든 문장을 조회합니다.

### 변경 사항
- **`WordListView`**: 모든 단어를 반환하는 API 엔드포인트 추가.
- **`SentenceListView`**: 모든 문장을 반환하는 API 엔드포인트 추가.
- **`WordSerializer`**: 단어와 연결된 문장을 포함한 시리얼라이저 추가.
- **`SentenceSerializer`**: 문장 정보를 시리얼라이징하는 시리얼라이저 추가.

### 세부 사항
- **`WordListView`**: 이 엔드포인트는 모든 단어를 조회하여 `WordSerializer`를 사용하여 응답을 반환합니다.
- **`SentenceListView`**: 이 엔드포인트는 모든 문장을 조회하여 `SentenceSerializer`를 사용하여 응답을 반환합니다.

### 테스트
- 각 API 엔드포인트에 대해 GET 요청을 실행하여 단어와 문장이 올바르게 반환되는지 확인합니다.
  - **GET /words/**: 반환되는 단어 리스트를 확인합니다.
  - **GET /sentences/**: 반환되는 문장 리스트를 확인합니다.

### 관련 이슈
- 없음
